### PR TITLE
bug: minor: default value for route

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
   </body>
   <script>
     // CHANGE THIS
-    const elabftwServerUrl = 'https://elab.local:3148/api/v2/';
+    const elabftwServerUrl = 'https://elab.local:3148/api/v2';
     const apiKey = 'apiKey4Test';
     // END configuration
     document.getElementById('getExp').addEventListener('click', () => {
       const headers = {'Content-Type': 'application/json', 'Authorization': apiKey};
-      fetch(`${elabftwServerUrl}api/v2/experiments`, { headers, method: 'GET'}).then(res => res.json()).then(json => {
+      fetch(`${elabftwServerUrl}/experiments`, { headers, method: 'GET'}).then(res => res.json()).then(json => {
         document.getElementById('output').innerText = JSON.stringify(json);
       });
     });


### PR DESCRIPTION
Just updating the default url to work out of the box.

- concatenated string resulted in `https://elab.local:3148/api/v2/api/v2/experiments`, now it's `https://elab.local:3148/api/v2/experiments`